### PR TITLE
disable expand

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/tidal-engineering/terraform-provider-spinnaker/spinnaker"
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/tidal-engineering/terraform-provider-spinnaker/spinnaker"
 )
 
 func main() {

--- a/spinnaker/api/application.go
+++ b/spinnaker/api/application.go
@@ -11,7 +11,9 @@ import (
 )
 
 func GetApplication(client *gate.GatewayClient, applicationName string, dest interface{}) error {
-	app, resp, err := client.ApplicationControllerApi.GetApplicationUsingGET(client.Context, applicationName, map[string]interface{}{})
+	app, resp, err := client.ApplicationControllerApi.GetApplicationUsingGET(client.Context, applicationName, map[string]interface{}{
+		"expand": false,
+	})
 	if resp != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Application '%s' not found\n", applicationName)


### PR DESCRIPTION
This is the default on GET operations in spin-cli: https://github.com/spinnaker/spin/blob/master/cmd/application/get.go#L42 - which is why spin-cli does not have performance issues fetching/listing applications.

Performance issues can be tested it out with:

* https://spinnaker-gate.INT/applications/dopething?expand=false
* https://spinnaker-gate.INTi/applications/dopething?expand=true

Partly mitigates https://github.com/spinnaker/spinnaker/issues/6084 for our foundation-repos at least.

Tested locally and its super fast now 😅 