### PR TITLE
Add release for the arm64 architecture

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     ignore:
       - goos: darwin
         goarch: "386"


### PR DESCRIPTION
This change adds `arm64` to the release architectures.

Closes #11 